### PR TITLE
Test with minimal signing in case new headers are added

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,6 +15,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/apple/swift-log.git", from: "1.2.1"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.21.0"),
         .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.0.0"),
         .package(url: "https://github.com/teco-project/teco-core.git", .upToNextMinor(from: "0.5.0-beta.2")),
@@ -34,6 +35,9 @@ let package = Package(
         ),
         .testTarget(
             name: "TecoCLSLoggingTests",
-            dependencies: ["TecoCLSLogging"]),
+            dependencies: [
+                "TecoCLSLogging",
+                .product(name: "NIOFoundationCompat", package: "swift-nio"),
+            ]),
     ]
 )

--- a/Sources/TecoCLSLogging/CLSLogHandler.swift
+++ b/Sources/TecoCLSLogging/CLSLogHandler.swift
@@ -37,7 +37,7 @@ public struct CLSLogHandler: LogHandler {
         }
     }
 
-    func uploadLogRequest(_ logGroup: Cls_LogGroup, credential: any Credential, date: Date = Date()) throws -> HTTPClient.Request {
+    func uploadLogRequest(_ logGroup: Cls_LogGroup, credential: any Credential, date: Date = Date(), signing: TCSigner.SigningMode = .default) throws -> HTTPClient.Request {
         let logGroupList = Cls_LogGroupList.with {
             $0.logGroupList = [logGroup]
         }
@@ -62,6 +62,7 @@ public struct CLSLogHandler: LogHandler {
                 "x-cls-topicid": self.topicID
             ],
             body: .data(data),
+            mode: signing,
             date: date
         )
 

--- a/Tests/TecoCLSLoggingTests/CLSLogHandlerTests.swift
+++ b/Tests/TecoCLSLoggingTests/CLSLogHandlerTests.swift
@@ -1,8 +1,9 @@
 import XCTest
 @testable import TecoCLSLogging
 import AsyncHTTPClient
-import TecoSigner
 import Logging
+import NIOFoundationCompat
+import TecoSigner
 
 final class CLSLogHandlerTests: XCTestCase {
     func testLogGroup() throws {

--- a/Tests/TecoCLSLoggingTests/CLSLogHandlerTests.swift
+++ b/Tests/TecoCLSLoggingTests/CLSLogHandlerTests.swift
@@ -48,7 +48,8 @@ final class CLSLogHandlerTests: XCTestCase {
             secretId: "AKIDz8krbsJ5yKBZQpn74WFkmLPx3EXAMPLE",
             secretKey: "Gu5t9xGARNpq86cd98joQYCN3EXAMPLE"
         )
-        let request = try logger.uploadLogRequest(logGroup, credential: credential, date: date)
+        // test with minimal signing here in case new headers are added
+        let request = try logger.uploadLogRequest(logGroup, credential: credential, date: date, signing: .minimal)
         XCTAssertEqual(request.method, .POST)
         XCTAssertEqual(request.host, "cls.tencentcloudapi.com")
 
@@ -76,7 +77,7 @@ final class CLSLogHandlerTests: XCTestCase {
         XCTAssertEqual(request.headers.first(name: "x-tc-region"), "ap-guangzhou")
         XCTAssertEqual(
             request.headers.first(name: "authorization"),
-            "TC3-HMAC-SHA256 Credential=AKIDz8krbsJ5yKBZQpn74WFkmLPx3EXAMPLE/2001-09-09/cls/tc3_request, SignedHeaders=content-type;host;x-cls-topicid;x-tc-action;x-tc-content-sha256;x-tc-region;x-tc-requestclient;x-tc-timestamp;x-tc-version, Signature=28613bf6feee6995b39d9db3e013f2d4699ec545115244e6a96b6d130a9dac25"
+            "TC3-HMAC-SHA256 Credential=AKIDz8krbsJ5yKBZQpn74WFkmLPx3EXAMPLE/2001-09-09/cls/tc3_request, SignedHeaders=content-type;host, Signature=1249e1b231a7a1c5d840c2c36d5e832a20671ab370256120fb6c1c9d26d28d12"
         )
     }
 }


### PR DESCRIPTION
This PR changed `CLSLogHandlerTests.testUploadRequest` to use minimal signing mode instead of the default.

The default signing mode is more secure so we should stick to it in production. However, since it can consume arbitrary headers, the tests may be broken occasionally due to new headers added. In some special cases, if `TCSigner` changed its header injection behavior, we cannot even maintain test compatibility across different `teco-core` versions.

Minimal signing mode takes only two of the required HTTP headers, making the test resistant to further changes.