### PR TITLE
Add support for metadata provider

### DIFF
--- a/Sources/TecoCLSLogging/CLS+init.swift
+++ b/Sources/TecoCLSLogging/CLS+init.swift
@@ -2,7 +2,7 @@ import Foundation
 import Logging
 
 extension Cls_LogGroup {
-    init(_ level: Logger.Level, message: Logger.Message, metadata: Logger.Metadata?, source: String, file: String, function: String, line: UInt, date: Date = Date()) {
+    init(_ level: Logger.Level, message: Logger.Message, metadata: Logger.Metadata, source: String, file: String, function: String, line: UInt, date: Date = Date()) {
         self = Self.with {
             $0.source = source
             $0.filename = file
@@ -14,12 +14,12 @@ extension Cls_LogGroup {
 }
 
 extension Cls_Log {
-    init(_ level: Logger.Level, message: Logger.Message, metadata: Logger.Metadata?, function: String, line: UInt, date: Date) {
+    init(_ level: Logger.Level, message: Logger.Message, metadata: Logger.Metadata, function: String, line: UInt, date: Date) {
         self = Self.with {
             var contents: [Content] = []
             contents.append(.init(key: "level", value: level.rawValue.uppercased()))
             contents.append(.init(key: "message", value: .stringConvertible(message)))
-            contents.append(contentsOf: metadata?.map(Content.init) ?? [])
+            contents.append(contentsOf: metadata.map(Content.init))
             contents.append(.init(key: "function", value: function))
             contents.append(.init(key: "line", value: .stringConvertible(line)))
             $0.contents = contents

--- a/Sources/TecoCLSLogging/CLSLogHandler.swift
+++ b/Sources/TecoCLSLogging/CLSLogHandler.swift
@@ -34,9 +34,7 @@ public struct CLSLogHandler: LogHandler {
     }
 
     public func log(level: Logger.Level, message: Logger.Message, metadata: Logger.Metadata?, source: String, file: String, function: String, line: UInt) {
-        let metadata = (metadataProvider?.get() ?? [:])
-            .merging(self.metadata, uniquingKeysWith: { $1 })
-            .merging(metadata ?? [:], uniquingKeysWith: { $1 })
+        let metadata = resolveMetadata(metadata)
         let log = Cls_LogGroup(level, message: message, metadata: metadata, source: source, file: file, function: function, line: line)
         precondition(log.isInitialized)
         if let request = try? self.uploadLogRequest(log, credential: self.credentialProvider()) {
@@ -44,7 +42,13 @@ public struct CLSLogHandler: LogHandler {
         }
     }
 
-    // MARK: Cloud Log Service APIs
+    // MARK: Internal implemenation
+
+    func resolveMetadata(_ metadata: Logger.Metadata?) -> Logger.Metadata {
+        return (metadataProvider?.get() ?? [:])
+            .merging(self.metadata, uniquingKeysWith: { $1 })
+            .merging(metadata ?? [:], uniquingKeysWith: { $1 })
+    }
 
     func uploadLogRequest(_ logGroup: Cls_LogGroup, credential: Credential, date: Date = Date(), signing: TCSigner.SigningMode = .default) throws -> HTTPClient.Request {
         let logGroupList = Cls_LogGroupList.with {

--- a/Sources/TecoCLSLogging/CLSLogHandler.swift
+++ b/Sources/TecoCLSLogging/CLSLogHandler.swift
@@ -20,8 +20,9 @@ public struct CLSLogHandler: LogHandler {
 
     // MARK: Log handler implemenation
 
-    public var metadata: Logger.Metadata = .init()
     public var logLevel: Logger.Level = .info
+    public var metadata: Logger.Metadata = .init()
+    public var metadataProvider: Logger.MetadataProvider?
 
     public subscript(metadataKey key: String) -> Logger.Metadata.Value? {
         get {
@@ -33,6 +34,9 @@ public struct CLSLogHandler: LogHandler {
     }
 
     public func log(level: Logger.Level, message: Logger.Message, metadata: Logger.Metadata?, source: String, file: String, function: String, line: UInt) {
+        let metadata = (metadataProvider?.get() ?? [:])
+            .merging(self.metadata, uniquingKeysWith: { $1 })
+            .merging(metadata ?? [:], uniquingKeysWith: { $1 })
         let log = Cls_LogGroup(level, message: message, metadata: metadata, source: source, file: file, function: function, line: line)
         precondition(log.isInitialized)
         if let request = try? self.uploadLogRequest(log, credential: self.credentialProvider()) {


### PR DESCRIPTION
This PR adds support for metadata provider in `CLSLogHandler`.

A metadata provider, introduced in swift-log 1.2, is usually a source of metadata generated from the context. We add a `var metadataProvider: Logger.Metadata?` member to `CLSLogHandler` and implement corresponding metadata merging logic.

We also fixed consuming metadata from the logger instance, and introduced a test to make sure we're merging metadata in the desired way.