### PR TITLE
Use Swift Concurrency with `AsyncHTTPClient`

### DIFF
--- a/Sources/TecoCLSLogging/CLSLogHandler.swift
+++ b/Sources/TecoCLSLogging/CLSLogHandler.swift
@@ -26,15 +26,15 @@ public struct CLSLogHandler: LogHandler {
 
     public subscript(metadataKey key: String) -> Logger.Metadata.Value? {
         get {
-            metadata[key]
+            self.metadata[key]
         }
         set {
-            metadata[key] = newValue
+            self.metadata[key] = newValue
         }
     }
 
     public func log(level: Logger.Level, message: Logger.Message, metadata: Logger.Metadata?, source: String, file: String, function: String, line: UInt) {
-        let metadata = resolveMetadata(metadata)
+        let metadata = self.resolveMetadata(metadata)
         let log = Cls_LogGroup(level, message: message, metadata: metadata, source: source, file: file, function: function, line: line)
         precondition(log.isInitialized)
         if let request = try? self.uploadLogRequest(log, credential: self.credentialProvider()) {
@@ -47,7 +47,7 @@ public struct CLSLogHandler: LogHandler {
     // MARK: Internal implemenation
 
     func resolveMetadata(_ metadata: Logger.Metadata?) -> Logger.Metadata {
-        return (metadataProvider?.get() ?? [:])
+        return (self.metadataProvider?.get() ?? [:])
             .merging(self.metadata, uniquingKeysWith: { $1 })
             .merging(metadata ?? [:], uniquingKeysWith: { $1 })
     }

--- a/Tests/TecoCLSLoggingTests/CLSLogHandlerTests.swift
+++ b/Tests/TecoCLSLoggingTests/CLSLogHandlerTests.swift
@@ -92,22 +92,6 @@ final class CLSLogHandlerTests: XCTestCase {
         // test with minimal signing here in case new headers are added
         let request = try logger.uploadLogRequest(logGroup, credential: credential, date: date, signing: .minimal)
         XCTAssertEqual(request.method, .POST)
-        XCTAssertEqual(request.host, "cls.tencentcloudapi.com")
-
-        // assert request body data
-        let data = Data([10, 183, 1, 10, 114, 8, 128, 148, 235, 220, 3, 18, 13, 10, 5, 108, 101, 118, 101, 108, 18, 4, 73, 78, 70, 79, 18, 31, 10, 7, 109, 101, 115, 115, 97, 103, 101, 18, 20, 84, 101, 115, 116, 32, 117, 112, 108, 111, 97, 100, 32, 114, 101, 113, 117, 101, 115, 116, 46, 18, 13, 10, 8, 116, 101, 115, 116, 45, 115, 101, 113, 18, 1, 50, 18, 31, 10, 8, 102, 117, 110, 99, 116, 105, 111, 110, 18, 19, 116, 101, 115, 116, 85, 112, 108, 111, 97, 100, 82, 101, 113, 117, 101, 115, 116, 40, 41, 18, 10, 10, 4, 108, 105, 110, 101, 18, 2, 51, 53, 26, 44, 84, 101, 99, 111, 67, 76, 83, 76, 111, 103, 103, 105, 110, 103, 84, 101, 115, 116, 115, 47, 67, 76, 83, 76, 111, 103, 72, 97, 110, 100, 108, 101, 114, 84, 101, 115, 116, 115, 46, 115, 119, 105, 102, 116, 34, 19, 84, 101, 99, 111, 67, 76, 83, 76, 111, 103, 103, 105, 110, 103, 84, 101, 115, 116, 115])
-        let body = try XCTUnwrap(request.body)
-        let tester = HTTPClient.Body.StreamWriter {
-            switch $0 {
-            case .byteBuffer(let byteBuffer):
-                let payload = byteBuffer.getData(at: 0, length: byteBuffer.readableBytes)
-                XCTAssertEqual(payload, data)
-            default:
-                XCTFail("Unexpectedly find file stream.")
-            }
-            return logger.client.eventLoopGroup.next().makeSucceededVoidFuture()
-        }
-        try body.stream(tester).wait()
 
         // assert request headers
         XCTAssertEqual(request.headers.first(name: "content-type"), "application/octet-stream")


### PR DESCRIPTION
This PR updates the internal implementation to use Swift Concurrency for HTTP requests, setting a 3-second timeout.

As a consequence, the internal HTTP request type changes from `HTTPClient.Request` to `HTTPClientRequest`, which doesn't expose the body since its lifecycle is fully managed. We removed assertions on `request.body` in `CLSLogHandlerTests.testUploadRequest` because the body is consumed in the signature, so if body changed unexpectedly the signature assertion will fail.