### PR TITLE
Add CI configuration for Swift 5.8

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,11 +26,16 @@ jobs:
           - '5.5'
           - '5.6'
           - '5.7'
+          - '5.8'
         exclude:
+          - os: macos-11
+            swift: '5.8'
           - os: macos-12
             swift: '5.5'
           - os: macos-12
             swift: '5.6'
+          - os: ubuntu-20.04
+            swift: '5.8'
           - os: ubuntu-22.04
             swift: '5.5'
           - os: ubuntu-22.04


### PR DESCRIPTION
This PR adds CI configuration for Swift 5.8, on macOS 12 and Ubuntu 22.04 runners.