### PR TITLE
Improve the reliability of `CLSLogAccumulator`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,9 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
+        .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.2"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.2.1"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.42.0"),
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.21.0"),
         .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.0.0"),
         .package(url: "https://github.com/teco-project/teco-core.git", .upToNextMinor(from: "0.5.0")),
@@ -27,6 +29,8 @@ let package = Package(
             dependencies: [
                 .product(name: "AsyncHTTPClient", package: "async-http-client"),
                 .product(name: "Logging", package: "swift-log"),
+                .product(name: "NIOConcurrencyHelpers", package: "swift-nio"),
+                .product(name: "NIOFoundationCompat", package: "swift-nio"),
                 .product(name: "SwiftProtobuf", package: "swift-protobuf"),
                 .product(name: "TecoSigner", package: "teco-core"),
             ],
@@ -36,6 +40,7 @@ let package = Package(
             name: "TecoCLSLoggingTests",
             dependencies: [
                 "TecoCLSLogging",
+                .product(name: "Atomics", package: "swift-atomics"),
             ]),
     ]
 )

--- a/Sources/TecoCLSLogging/CLSLogAccumulator.swift
+++ b/Sources/TecoCLSLogging/CLSLogAccumulator.swift
@@ -84,12 +84,7 @@ class CLSLogAccumulator {
         }
 
         // upload logs
-        let requestID = try await uploader(.init(batch))
-        #if DEBUG
-        print("CLS logs sent with request ID: \(requestID)")
-        #else
-        _ = requestID
-        #endif
+        _ = try await uploader(.init(batch))
     }
 
     private var shouldUpload: Bool {

--- a/Tests/TecoCLSLoggingTests/CLSLogAccumulatorTests.swift
+++ b/Tests/TecoCLSLoggingTests/CLSLogAccumulatorTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+@testable import TecoCLSLogging
+import AsyncHTTPClient
+import Atomics
+
+final class CLSLogAccumulatorTests: XCTestCase {
+    func testBatchSize() async throws {
+        // set up test helpers
+        let batches = ManagedAtomic(0)
+        func upload(_ logs: [Cls_LogGroup]) throws -> String {
+            XCTAssertLessThanOrEqual(logs.count, 2)
+            batches.wrappingIncrement(ordering: .relaxed)
+            return "mock-upload-id"
+        }
+
+        // create log accumulator
+        let accumulator = CLSLogAccumulator(
+            maxBatchSize: 2,
+            maxWaitNanoseconds: nil,
+            uploader: upload
+        )
+
+        // test adding logs
+        for id in 0...10 {
+            accumulator.addLog(
+                .init(.debug, message: "Hello with ID#\(id)",
+                      source: "TecoCLSLoggingTests",
+                      file: #fileID, function: #function, line: #line)
+            )
+        }
+
+        // force flush the logger to upload logs
+        try accumulator.forceFlush()
+
+        // assert batch counts
+        XCTAssertEqual(batches.load(ordering: .acquiring), 6)
+    }
+
+    func testWaitDuration() async throws {
+        // set up test helpers
+        func upload(_ logs: [Cls_LogGroup]) throws -> String {
+            XCTAssertLessThanOrEqual(logs.count, 3)
+            return "mock-upload-id"
+        }
+
+        // create log accumulator
+        let accumulator = CLSLogAccumulator(
+            maxBatchSize: 5,
+            maxWaitNanoseconds: 200_000_000,
+            uploader: upload
+        )
+
+        // test adding logs
+        for id in 0...10 {
+            accumulator.addLog(
+                .init(.debug, message: "Hello with ID#\(id)",
+                      source: "TecoCLSLoggingTests",
+                      file: #fileID, function: #function, line: #line)
+            )
+            try await Task.sleep(nanoseconds: 100_000_000)
+        }
+    }
+}

--- a/Tests/TecoCLSLoggingTests/CLSLogClientTests.swift
+++ b/Tests/TecoCLSLoggingTests/CLSLogClientTests.swift
@@ -1,0 +1,67 @@
+import XCTest
+@testable import TecoCLSLogging
+import AsyncHTTPClient
+import TecoSigner
+
+final class CLSLogClientTests: XCTestCase {
+    func testLogGroup() throws {
+        let data = Data([10, 104, 8, 128, 148, 235, 220, 3, 18, 14, 10, 5, 108, 101, 118, 101, 108, 18, 5, 68, 69, 66, 85, 71, 18, 26, 10, 7, 109, 101, 115, 115, 97, 103, 101, 18, 15, 84, 101, 115, 116, 32, 108, 111, 103, 32, 103, 114, 111, 117, 112, 46, 18, 13, 10, 8, 116, 101, 115, 116, 45, 115, 101, 113, 18, 1, 49, 18, 26, 10, 8, 102, 117, 110, 99, 116, 105, 111, 110, 18, 14, 116, 101, 115, 116, 76, 111, 103, 71, 114, 111, 117, 112, 40, 41, 18, 9, 10, 4, 108, 105, 110, 101, 18, 1, 49, 26, 44, 84, 101, 99, 111, 67, 76, 83, 76, 111, 103, 103, 105, 110, 103, 84, 101, 115, 116, 115, 47, 67, 76, 83, 76, 111, 103, 72, 97, 110, 100, 108, 101, 114, 84, 101, 115, 116, 115, 46, 115, 119, 105, 102, 116, 34, 19, 84, 101, 99, 111, 67, 76, 83, 76, 111, 103, 103, 105, 110, 103, 84, 101, 115, 116, 115])
+        let logGroup = Cls_LogGroup(
+            .debug,
+            message: "Test log group.",
+            metadata: ["test-seq": "1"],
+            source: "TecoCLSLoggingTests",
+            file: "TecoCLSLoggingTests/CLSLogHandlerTests.swift",
+            function: "testLogGroup()",
+            line: 1,
+            date: Date(timeIntervalSince1970: 1_000_000_000)
+        )
+        XCTAssertEqual(try logGroup.serializedData(), data)
+    }
+
+    func testUploadRequest() throws {
+        // create log client
+        let client = CLSLogClient(
+            client: .init(eventLoopGroupProvider: .createNew),
+            credentialProvider: { StaticCredential(secretId: "", secretKey: "") },
+            region: "ap-guangzhou",
+            topicID: "xxxxxxxx-xxxx-xxxx-xxxx"
+        )
+        defer { try? client.client.syncShutdown() }
+
+        // build log group
+        let date = Date(timeIntervalSince1970: 1_000_000_000)
+        let logGroupList = Cls_LogGroupList([
+            Cls_LogGroup(
+                .info,
+                message: "Test upload request.",
+                source: "TecoCLSLoggingTests",
+                file: "TecoCLSLoggingTests/CLSLogHandlerTests.swift",
+                function: "testUploadRequest()",
+                line: 1,
+                date: date
+            )
+        ])
+
+        // build and assert request basics
+        let credential = StaticCredential(
+            secretId: "AKIDz8krbsJ5yKBZQpn74WFkmLPx3EXAMPLE",
+            secretKey: "Gu5t9xGARNpq86cd98joQYCN3EXAMPLE"
+        )
+        // test with minimal signing here in case new headers are added
+        let request = try client.uploadLogRequest(logGroupList, credential: credential, date: date, signing: .minimal)
+        XCTAssertEqual(request.method, .POST)
+
+        // assert request headers
+        XCTAssertEqual(request.headers.first(name: "content-type"), "application/octet-stream")
+        XCTAssertEqual(request.headers.first(name: "host"), "cls.tencentcloudapi.com")
+        XCTAssertEqual(request.headers.first(name: "x-cls-topicid"), "xxxxxxxx-xxxx-xxxx-xxxx")
+        XCTAssertEqual(request.headers.first(name: "x-tc-action"), "UploadLog")
+        XCTAssertEqual(request.headers.first(name: "x-tc-version"), "2020-10-16")
+        XCTAssertEqual(request.headers.first(name: "x-tc-region"), "ap-guangzhou")
+        XCTAssertEqual(
+            request.headers.first(name: "authorization"),
+            "TC3-HMAC-SHA256 Credential=AKIDz8krbsJ5yKBZQpn74WFkmLPx3EXAMPLE/2001-09-09/cls/tc3_request, SignedHeaders=content-type;host, Signature=4650f896956144eae9f5bafbd14f8ad6c62dea02ea297d280658468fb3cac765"
+        )
+    }
+}

--- a/Tests/TecoCLSLoggingTests/CLSLogHandlerTests.swift
+++ b/Tests/TecoCLSLoggingTests/CLSLogHandlerTests.swift
@@ -1,25 +1,9 @@
 import XCTest
 @testable import TecoCLSLogging
-import AsyncHTTPClient
 import Logging
 import TecoSigner
 
 final class CLSLogHandlerTests: XCTestCase {
-    func testLogGroup() throws {
-        let data = Data([10, 104, 8, 128, 148, 235, 220, 3, 18, 14, 10, 5, 108, 101, 118, 101, 108, 18, 5, 68, 69, 66, 85, 71, 18, 26, 10, 7, 109, 101, 115, 115, 97, 103, 101, 18, 15, 84, 101, 115, 116, 32, 108, 111, 103, 32, 103, 114, 111, 117, 112, 46, 18, 13, 10, 8, 116, 101, 115, 116, 45, 115, 101, 113, 18, 1, 49, 18, 26, 10, 8, 102, 117, 110, 99, 116, 105, 111, 110, 18, 14, 116, 101, 115, 116, 76, 111, 103, 71, 114, 111, 117, 112, 40, 41, 18, 9, 10, 4, 108, 105, 110, 101, 18, 1, 49, 26, 44, 84, 101, 99, 111, 67, 76, 83, 76, 111, 103, 103, 105, 110, 103, 84, 101, 115, 116, 115, 47, 67, 76, 83, 76, 111, 103, 72, 97, 110, 100, 108, 101, 114, 84, 101, 115, 116, 115, 46, 115, 119, 105, 102, 116, 34, 19, 84, 101, 99, 111, 67, 76, 83, 76, 111, 103, 103, 105, 110, 103, 84, 101, 115, 116, 115])
-        let logGroup = Cls_LogGroup(
-            .debug,
-            message: "Test log group.",
-            metadata: ["test-seq": "1"],
-            source: "TecoCLSLoggingTests",
-            file: "TecoCLSLoggingTests/CLSLogHandlerTests.swift",
-            function: "testLogGroup()",
-            line: 1,
-            date: Date(timeIntervalSince1970: 1_000_000_000)
-        )
-        XCTAssertEqual(try logGroup.serializedData(), data)
-    }
-
     func testResolveMetadata() throws {
         // create logger
         var logger = CLSLogHandler(
@@ -124,7 +108,7 @@ final class CLSLogHandlerTests: XCTestCase {
                 topicID: "xxxxxxxx-xxxx-xxxx-xxxx"
             ),
             accumulator: .init(
-                maxBatchSize: 4,
+                maxBatchSize: 3,
                 maxWaitNanoseconds: nil,
                 uploader: upload
             )
@@ -138,8 +122,5 @@ final class CLSLogHandlerTests: XCTestCase {
         logger.info("Test 1")
         logger.error("Test 2", metadata: ["reason" : "test error"])
         logger.warning("Test 3")
-
-        // force flush the logger to upload logs
-        try logHandler.accumulator.forceFlush()
     }
 }


### PR DESCRIPTION
This PR addresses some corner cases in `CLSLogAccumulator` for a more robust handling process. It also reorganizes the tests and adds two dedicated test cases for the accumulator.