### PR TITLE
Renames `CLSLogAccumulator` to `CLSLogQueue`

### DIFF
--- a/Sources/TecoCLSLogging/CLSLogHandler.swift
+++ b/Sources/TecoCLSLogging/CLSLogHandler.swift
@@ -5,7 +5,7 @@ import protocol TecoSigner.Credential
 public struct CLSLogHandler: LogHandler {
 
     public let client: CLSLogClient
-    internal let accumulator: CLSLogAccumulator
+    internal let queue: CLSLogQueue
 
     public init(
         client: HTTPClient,
@@ -16,7 +16,7 @@ public struct CLSLogHandler: LogHandler {
         maxWaitNanoseconds: UInt? = nil
     ) {
         self.client = .init(client: client, credentialProvider: credentialProvider, region: region, topicID: topicID)
-        self.accumulator = .init(maxBatchSize: maxBatchSize, maxWaitNanoseconds: maxWaitNanoseconds, uploader: self.client.uploadLogs)
+        self.queue = .init(maxBatchSize: maxBatchSize, maxWaitNanoseconds: maxWaitNanoseconds, uploader: self.client.uploadLogs)
     }
 
     // MARK: Log handler implemenation
@@ -38,7 +38,7 @@ public struct CLSLogHandler: LogHandler {
         let metadata = self.resolveMetadata(metadata)
         let log = Cls_LogGroup(level, message: message, metadata: metadata, source: source, file: file, function: function, line: line)
         assert(log.isInitialized)
-        self.accumulator.addLog(log)
+        self.queue.enqueue(log)
     }
 
     // MARK: Internal implemenation
@@ -51,8 +51,8 @@ public struct CLSLogHandler: LogHandler {
 
     // MARK: Test utility
 
-    internal init(client: CLSLogClient, accumulator: CLSLogAccumulator) {
+    internal init(client: CLSLogClient, queue: CLSLogQueue) {
         self.client = client
-        self.accumulator = accumulator
+        self.queue = queue
     }
 }

--- a/Sources/TecoCLSLogging/CLSLogHandler.swift
+++ b/Sources/TecoCLSLogging/CLSLogHandler.swift
@@ -5,18 +5,17 @@ import protocol TecoSigner.Credential
 public struct CLSLogHandler: LogHandler {
 
     public let client: CLSLogClient
-    internal let queue: CLSLogQueue
+    public let queue: CLSLogQueue
 
     public init(
         client: HTTPClient,
         credentialProvider: @escaping () -> Credential,
         region: String,
         topicID: String,
-        maxBatchSize: UInt = 4,
-        maxWaitNanoseconds: UInt? = nil
+        queueConfig: CLSLogQueue.Configuration = .init()
     ) {
         self.client = .init(client: client, credentialProvider: credentialProvider, region: region, topicID: topicID)
-        self.queue = .init(maxBatchSize: maxBatchSize, maxWaitNanoseconds: maxWaitNanoseconds, uploader: self.client.uploadLogs)
+        self.queue = .init(configuration: queueConfig, uploader: self.client.uploadLogs)
     }
 
     // MARK: Log handler implemenation

--- a/Tests/TecoCLSLoggingTests/CLSLogHandlerTests.swift
+++ b/Tests/TecoCLSLoggingTests/CLSLogHandlerTests.swift
@@ -99,7 +99,7 @@ final class CLSLogHandlerTests: XCTestCase {
             return "mock-upload-id"
         }
 
-        // create log handler with custom accumulator
+        // create log handler with custom queue
         let logHandler = CLSLogHandler(
             client: .init(
                 client: .init(eventLoopGroupProvider: .createNew),
@@ -107,7 +107,7 @@ final class CLSLogHandlerTests: XCTestCase {
                 region: "ap-guangzhou",
                 topicID: "xxxxxxxx-xxxx-xxxx-xxxx"
             ),
-            accumulator: .init(
+            queue: .init(
                 maxBatchSize: 3,
                 maxWaitNanoseconds: nil,
                 uploader: upload

--- a/Tests/TecoCLSLoggingTests/CLSLogHandlerTests.swift
+++ b/Tests/TecoCLSLoggingTests/CLSLogHandlerTests.swift
@@ -107,11 +107,7 @@ final class CLSLogHandlerTests: XCTestCase {
                 region: "ap-guangzhou",
                 topicID: "xxxxxxxx-xxxx-xxxx-xxxx"
             ),
-            queue: .init(
-                maxBatchSize: 3,
-                maxWaitNanoseconds: nil,
-                uploader: upload
-            )
+            queue: .init(configuration: .init(maxBatchSize: 3), uploader: upload)
         )
 
         // we're not actually sending any requests here

--- a/Tests/TecoCLSLoggingTests/CLSLogQueueTests.swift
+++ b/Tests/TecoCLSLoggingTests/CLSLogQueueTests.swift
@@ -3,7 +3,7 @@ import XCTest
 import AsyncHTTPClient
 import Atomics
 
-final class CLSLogAccumulatorTests: XCTestCase {
+final class CLSLogQueueTests: XCTestCase {
     func testBatchSize() async throws {
         // set up test helpers
         let batches = ManagedAtomic(0)
@@ -13,8 +13,8 @@ final class CLSLogAccumulatorTests: XCTestCase {
             return "mock-upload-id"
         }
 
-        // create log accumulator
-        let accumulator = CLSLogAccumulator(
+        // create log queue
+        let queue = CLSLogQueue(
             maxBatchSize: 2,
             maxWaitNanoseconds: nil,
             uploader: upload
@@ -22,7 +22,7 @@ final class CLSLogAccumulatorTests: XCTestCase {
 
         // test adding logs
         for id in 0...10 {
-            accumulator.addLog(
+            queue.enqueue(
                 .init(.debug, message: "Hello with ID#\(id)",
                       source: "TecoCLSLoggingTests",
                       file: #fileID, function: #function, line: #line)
@@ -30,7 +30,7 @@ final class CLSLogAccumulatorTests: XCTestCase {
         }
 
         // force flush the logger to upload logs
-        try accumulator.forceFlush()
+        try queue.forceFlush()
 
         // assert batch counts
         XCTAssertEqual(batches.load(ordering: .acquiring), 6)
@@ -43,8 +43,8 @@ final class CLSLogAccumulatorTests: XCTestCase {
             return "mock-upload-id"
         }
 
-        // create log accumulator
-        let accumulator = CLSLogAccumulator(
+        // create log queue
+        let queue = CLSLogQueue(
             maxBatchSize: 5,
             maxWaitNanoseconds: 200_000_000,
             uploader: upload
@@ -52,7 +52,7 @@ final class CLSLogAccumulatorTests: XCTestCase {
 
         // test adding logs
         for id in 0...10 {
-            accumulator.addLog(
+            queue.enqueue(
                 .init(.debug, message: "Hello with ID#\(id)",
                       source: "TecoCLSLoggingTests",
                       file: #fileID, function: #function, line: #line)

--- a/Tests/TecoCLSLoggingTests/CLSLogQueueTests.swift
+++ b/Tests/TecoCLSLoggingTests/CLSLogQueueTests.swift
@@ -9,7 +9,7 @@ final class CLSLogQueueTests: XCTestCase {
         let batches = ManagedAtomic(0)
         func upload(_ logs: [Cls_LogGroup]) throws -> String {
             XCTAssertLessThanOrEqual(logs.count, 2)
-            batches.wrappingIncrement(ordering: .relaxed)
+            batches.wrappingIncrement(ordering: .sequentiallyConsistent)
             return "mock-upload-id"
         }
 
@@ -27,9 +27,10 @@ final class CLSLogQueueTests: XCTestCase {
 
         // force flush the logger to upload logs
         try queue.forceFlush()
+        try await Task.sleep(nanoseconds: 10_000_000)
 
         // assert batch counts
-        XCTAssertEqual(batches.load(ordering: .acquiring), 6)
+        XCTAssertEqual(batches.load(ordering: .sequentiallyConsistent), 6)
     }
 
     func testWaitDuration() async throws {

--- a/Tests/TecoCLSLoggingTests/CLSLogQueueTests.swift
+++ b/Tests/TecoCLSLoggingTests/CLSLogQueueTests.swift
@@ -14,11 +14,7 @@ final class CLSLogQueueTests: XCTestCase {
         }
 
         // create log queue
-        let queue = CLSLogQueue(
-            maxBatchSize: 2,
-            maxWaitNanoseconds: nil,
-            uploader: upload
-        )
+        let queue = CLSLogQueue(configuration: .init(maxBatchSize: 2), uploader: upload)
 
         // test adding logs
         for id in 0...10 {
@@ -45,8 +41,7 @@ final class CLSLogQueueTests: XCTestCase {
 
         // create log queue
         let queue = CLSLogQueue(
-            maxBatchSize: 5,
-            maxWaitNanoseconds: 200_000_000,
+            configuration: .init(maxBatchSize: 5, maxWaitNanoseconds: 200_000_000),
             uploader: upload
         )
 


### PR DESCRIPTION
This PR renames the previous `CLSLogAccumulator` to `CLSLogQueue` to better reflect its usage, and makes it public to library users. It also refines the API by introducing the `CLSLogQueue.Configuration` structure.